### PR TITLE
Update numbat-go-lint.yml

### DIFF
--- a/.github/workflows/numbat-go-lint.yml
+++ b/.github/workflows/numbat-go-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest


### PR DESCRIPTION
- chore: update go-lint version from 1.19 to 1.20, otherwise go-lint seems to fail